### PR TITLE
added aggregatedTrim functionality, can search 520d after 5 SERIES now.

### DIFF
--- a/autotrader_scraper/scraper.py
+++ b/autotrader_scraper/scraper.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 import traceback
 import cloudscraper
 
-def get_cars(make="BMW", model="5 SERIES", postcode="SW1A 0AA", radius=1500, min_year=1995, max_year=1995, include_writeoff="include", max_attempts_per_page=5, verbose=False):
+def get_cars(make="BMW", model="5 SERIES", postcode="SW1A 0AA", radius=1500, min_year=1995, max_year=1995, include_writeoff="include", max_attempts_per_page=5, verbose=False, **kwargs):
 
 	# To bypass Cloudflare protection
 	scraper = cloudscraper.create_scraper()
@@ -39,6 +39,9 @@ def get_cars(make="BMW", model="5 SERIES", postcode="SW1A 0AA", radius=1500, min
 		"search-results-price-type": "total-price",
 		"search-results-year": "select-year",
 	}
+
+	if 'trim' in kwargs:
+		params["aggregatedTrim"] = kwargs['trim']
 
 	if (include_writeoff == "include"):
 		params["writeoff-categories"] = "on"


### PR DESCRIPTION
`aggregatedTrim` added to `**kwargs`. Use by passing `trim` as a parameter to `get_cars()` function.

Example:

When searching for Mercedes-Benz C Class. Current code returns all C Class cars with no ability to narrow search down to C43 for example. With `aggregatedTrim='C43 V6'` we can narrow down the search. 

Usage:

```python
get_cars(
        make = "Mercedes-Benz",
        model = "C Class",
        min_year = 2005,
        max_year = 2022,
        include_writeoff = "include",
        max_attempts_per_page = 5,
        verbose = False,
        trim='C43 V6'
    )
```