### PR TITLE
Vehicle trim functionality support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To update from an older version, the best way is to run `pip3 uninstall autotrad
 |-|-|-|-|-|
 | make | String | Make of the car | Get these from autotrader.co.uk\*. Examples are "Audi", "BMW", "Jaguar" |"BMW"|
 | model | String | Model of the car | Get these from autotrader.co.uk\*. Examples are "A3", "A4", "A4" for Audi |"5 SERIES"|
+| variant | String (optional) | Variant of the car/trim | Get these from autotrader.co.uk\*. Examples are "520d", "S-Line", "340i |"540i"|
 | postcode | String | Postcode where you are searching | Example: "CB2 1TN", "NW1 2BH" | "SW1A 0AA" |
 | radius | Integer | Radius of your search from the postcode | Can be any positive integer. Use 1500 for nation-wide search | 1500 (i.e. nation-wide) |
 | min_year | Integer | Minimum year of the car's manufacture | Can be any positive integer | 1995 |

--- a/autotrader_scraper/scraper.py
+++ b/autotrader_scraper/scraper.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 import traceback
 import cloudscraper
 
-def get_cars(make="BMW", model="5 SERIES", postcode="SW1A 0AA", radius=1500, min_year=1995, max_year=1995, include_writeoff="include", max_attempts_per_page=5, verbose=False):
+def get_cars(make="BMW", model="3 SERIES", variant=False, postcode="SW1A 0AA", radius=1500, min_year=1995, max_year=1995, include_writeoff="include", max_attempts_per_page=5, verbose=False):
 
 	# To bypass Cloudflare protection
 	scraper = cloudscraper.create_scraper()
@@ -47,6 +47,10 @@ def get_cars(make="BMW", model="5 SERIES", postcode="SW1A 0AA", radius=1500, min
 	elif (include_writeoff == "writeoff-only"):
 		params["only-writeoff-categories"] = "on"
 		
+
+	if (variant):
+		params["aggregatedTrim"] = variant
+
 	year = min_year
 	page = 1
 	attempt = 1

--- a/autotrader_scraper/scraper.py
+++ b/autotrader_scraper/scraper.py
@@ -107,7 +107,7 @@ def get_cars(make="BMW", model="3 SERIES", variant=False, postcode="SW1A 0AA", r
 						for article in articles:
 							car = {}
 							car["name"] = article.find("h3", {"class": "product-card-details__title"}).text.strip()				
-							car["link"] = "https://www.autotrader.co.uk" + article.find("a", {"class": "tracking-standard-link"})["href"][: article.find("a", {"class": "tracking-standard-link"})["href"].find("?")]
+							car["link"] = "https://www.autotrader.co.uk" + article.find("a", {"class": "listing-fpa-link"})["href"][: article.find("a", {"class": "listing-fpa-link"})["href"].find("?")]
 							car["price"] = article.find("div", {"class": "product-card-pricing__price"}).text.strip()
 
 							key_specs_bs_list = article.find("ul", {"class": "listing-key-specs"}).find_all("li")


### PR DESCRIPTION
Allows for the variant (aggregatedTrim) on the autotrader website.

Can be included/excluded from search function and is not a required variable for function to work.